### PR TITLE
feat: disable vue/html-indent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ export async function empathyco(options: AntfuParams[0] = {}, ...userConfigs: An
         // Disable vue rules that conflicts with Prettier
         'vue/singleline-html-element-content-newline': 'off',
         'vue/html-self-closing': 'off',
+        'vue/html-indent': 'off',
         // https://typescript-eslint.io/rules/strict-boolean-expressions/
         '@typescript-eslint/strict-boolean-expressions': 'off',
       },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/622ee14c-406c-4ad9-bdb1-2f4af8555eba)

Red: prettier
Green: eslint

Multiline condition indentation inside template attrs conflicts with prettier.