### PR TITLE
feat: add prettier-plugin-tailwind

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "@antfu/eslint-config": "4.6.0",
         "eslint": "9.21.0",
-        "prettier": "3.5.3"
+        "prettier": "3.5.3",
+        "prettier-plugin-tailwindcss": "0.6.11"
       },
       "devDependencies": {
         "jiti": "2.4.2",
@@ -5730,6 +5731,84 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-tailwindcss": {
+      "version": "0.6.11",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.11.tgz",
+      "integrity": "sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.21.3"
+      },
+      "peerDependencies": {
+        "@ianvs/prettier-plugin-sort-imports": "*",
+        "@prettier/plugin-pug": "*",
+        "@shopify/prettier-plugin-liquid": "*",
+        "@trivago/prettier-plugin-sort-imports": "*",
+        "@zackad/prettier-plugin-twig": "*",
+        "prettier": "^3.0",
+        "prettier-plugin-astro": "*",
+        "prettier-plugin-css-order": "*",
+        "prettier-plugin-import-sort": "*",
+        "prettier-plugin-jsdoc": "*",
+        "prettier-plugin-marko": "*",
+        "prettier-plugin-multiline-arrays": "*",
+        "prettier-plugin-organize-attributes": "*",
+        "prettier-plugin-organize-imports": "*",
+        "prettier-plugin-sort-imports": "*",
+        "prettier-plugin-style-order": "*",
+        "prettier-plugin-svelte": "*"
+      },
+      "peerDependenciesMeta": {
+        "@ianvs/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@prettier/plugin-pug": {
+          "optional": true
+        },
+        "@shopify/prettier-plugin-liquid": {
+          "optional": true
+        },
+        "@trivago/prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "@zackad/prettier-plugin-twig": {
+          "optional": true
+        },
+        "prettier-plugin-astro": {
+          "optional": true
+        },
+        "prettier-plugin-css-order": {
+          "optional": true
+        },
+        "prettier-plugin-import-sort": {
+          "optional": true
+        },
+        "prettier-plugin-jsdoc": {
+          "optional": true
+        },
+        "prettier-plugin-marko": {
+          "optional": true
+        },
+        "prettier-plugin-multiline-arrays": {
+          "optional": true
+        },
+        "prettier-plugin-organize-attributes": {
+          "optional": true
+        },
+        "prettier-plugin-organize-imports": {
+          "optional": true
+        },
+        "prettier-plugin-sort-imports": {
+          "optional": true
+        },
+        "prettier-plugin-style-order": {
+          "optional": true
+        },
+        "prettier-plugin-svelte": {
+          "optional": true
+        }
       }
     },
     "node_modules/punycode": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
   "dependencies": {
     "@antfu/eslint-config": "4.6.0",
     "eslint": "9.21.0",
-    "prettier": "3.5.3"
+    "prettier": "3.5.3",
+    "prettier-plugin-tailwindcss": "0.6.11"
   },
   "devDependencies": {
     "jiti": "2.4.2",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,9 +1,11 @@
-const config = {
+import { loadPrettierPlugins } from './src/utils/loadPrettierPlugins.js'
+
+export default {
   printWidth: 100,
   singleQuote: true,
   arrowParens: 'avoid',
   semi: false,
-  plugins: ['prettier-plugin-tailwindcss'],
+  plugins: loadPrettierPlugins(),
   overrides: [
     {
       files: '*.svg',
@@ -13,5 +15,3 @@ const config = {
     },
   ],
 }
-
-export default config

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,6 +3,7 @@ const config = {
   singleQuote: true,
   arrowParens: 'avoid',
   semi: false,
+  plugins: ['prettier-plugin-tailwindcss'],
   overrides: [
     {
       files: '*.svg',

--- a/src/utils/loadPrettierPlugins.js
+++ b/src/utils/loadPrettierPlugins.js
@@ -1,0 +1,31 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import process from 'node:process'
+
+/**
+ * Checks if Tailwind is installed in the project's dependencies.
+ */
+function isTailwindInstalled() {
+  try {
+    const packageJsonPath = resolve(process.cwd(), 'package.json')
+    if (!existsSync(packageJsonPath)) return false
+
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
+    return Boolean(
+      packageJson.dependencies?.tailwindcss || packageJson.devDependencies?.tailwindcss,
+    )
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Dynamically loads Prettier plugins based on project dependencies.
+ */
+export function loadPrettierPlugins() {
+  const plugins = []
+  if (isTailwindInstalled()) {
+    plugins.push('prettier-plugin-tailwindcss')
+  }
+  return plugins
+}


### PR DESCRIPTION
Issue #21

Add `prettier-plugin-tailwind` in order to sort Tailwind classes easily

More info here: [Automatic class sorting with prettier](https://tailwindcss.com/blog/automatic-class-sorting-with-prettier)

Example:
![image](https://github.com/user-attachments/assets/eda75a95-6294-41a4-b678-7db7fbb39a1a)