### PR TITLE
feat(prettier): add SVG file formatting

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,6 +3,14 @@ const config = {
   singleQuote: true,
   arrowParens: 'avoid',
   semi: false,
+  overrides: [
+    {
+      files: '*.svg',
+      options: {
+        parser: 'html',
+      },
+    },
+  ],
 }
 
 export default config


### PR DESCRIPTION
Format SVGs like HTML files

It seems to be enough, even though SVG is an XML-based markup language.

based on https://github.com/prettier/prettier/discussions/14424 & https://github.com/prettier/prettier/issues/5322#issuecomment-1276302630