### PR TITLE
fix: prettier plugin applies in Nuxt projects

### DIFF
--- a/src/utils/loadPrettierPlugins.js
+++ b/src/utils/loadPrettierPlugins.js
@@ -11,9 +11,13 @@ function isTailwindInstalled() {
     if (!existsSync(packageJsonPath)) return false
 
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'))
-    return Boolean(
-      packageJson.dependencies?.tailwindcss || packageJson.devDependencies?.tailwindcss,
-    )
+
+    const deps = {
+      ...(packageJson.dependencies || {}),
+      ...(packageJson.devDependencies || {}),
+    }
+
+    return Boolean(deps.tailwindcss || deps['@nuxtjs/tailwindcss'])
   } catch {
     return false
   }


### PR DESCRIPTION
Nuxt projects do not include the literal `tailwindcss` in either their packager.json nor package-lock.json. Therefore, the plugin acts as if Tailwind is not installed.