### PR TITLE
refactor(utils): use dynamic import for prettier-plugin-tailwindcss

### DIFF
--- a/src/utils/loadPrettierPlugins.js
+++ b/src/utils/loadPrettierPlugins.js
@@ -46,7 +46,7 @@ function isTailwindInstalled() {
 export function loadPrettierPlugins() {
   const plugins = []
   if (isTailwindInstalled()) {
-    plugins.push('prettier-plugin-tailwindcss')
+    plugins.push(import('prettier-plugin-tailwindcss'))
   }
   return plugins
 }


### PR DESCRIPTION
Origin: https://github.com/empathyco/motive-market/actions/runs/16136975797/job/45535281783#step:15:12
Following this issue https://github.com/tailwindlabs/prettier-plugin-tailwindcss/issues/329#issuecomment-2663887539 

This pull request updates the `loadPrettierPlugins` function in `src/utils/loadPrettierPlugins.js` to dynamically import the `prettier-plugin-tailwindcss` module instead of using a static string reference.

Key change:

* [`src/utils/loadPrettierPlugins.js`](diffhunk://#diff-94a037af7ef0c8c2ec04aed8a1ae0b17213352d6f0cff48f6c855209c036a974L49-R49): Modified the `isTailwindInstalled` check to dynamically import the `prettier-plugin-tailwindcss` module, improving compatibility and ensuring the plugin is loaded correctly.